### PR TITLE
Add React speech-to-speech app powered by OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=tu_clave_de_openai
+PORT=5000
+# VITE_API_URL=http://localhost:5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+.env.local
+npm-debug.log*
+dist
+.DS_Store

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,47 @@
-This is the Readme
+# Speach IA
+
+Aplicación web en React que permite convertir voz a voz usando los servicios de OpenAI. La app captura audio desde el navegador, transcribe lo que el usuario dijo y devuelve una respuesta hablada generada por un asistente IA.
+
+## Requisitos
+
+- Node.js 18 o superior
+- Una clave válida de OpenAI almacenada en la variable de entorno `OPENAI_API_KEY`
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Desarrollo
+
+Ejecuta el servidor de desarrollo (cliente + API) con:
+
+```bash
+npm run dev
+```
+
+Esto levanta Vite en `http://localhost:5173` y un servidor Express en `http://localhost:5000`. Gracias al proxy configurado, el cliente redirige las peticiones a `/api` hacia el backend.
+
+## Producción
+
+1. Compila la aplicación React:
+
+   ```bash
+   npm run build
+   ```
+
+2. Inicia el servidor Express que sirve los archivos compilados y expone el endpoint `/api/speech`:
+
+   ```bash
+   npm start
+   ```
+
+## Uso
+
+1. Abre la aplicación en el navegador y concede permisos de micrófono.
+2. Pulsa **Comenzar a hablar** para grabar tu pregunta.
+3. Detén la grabación para enviar el audio al backend.
+4. El asistente transcribe tu voz, genera una respuesta y la reproduce automáticamente.
+
+Si deseas apuntar a un backend desplegado en otra URL puedes definir `VITE_API_URL` en un archivo `.env` en la raíz del proyecto.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Speach IA</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "speach-ia",
+  "version": "1.0.0",
+  "description": "Aplicación React de speech-to-speech con OpenAI",
+  "type": "module",
+  "scripts": {
+    "dev": "npm-run-all --parallel dev:client dev:server",
+    "dev:client": "vite",
+    "dev:server": "node server/index.js",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "node server/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.50.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "npm-run-all": "^4.1.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,92 @@
+import express from 'express';
+import cors from 'cors';
+import multer from 'multer';
+import dotenv from 'dotenv';
+import { OpenAI } from 'openai';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+dotenv.config();
+
+const app = express();
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 25 * 1024 * 1024 } });
+
+app.use(cors());
+app.use(express.json());
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+app.post('/api/speech', upload.single('audio'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'Archivo de audio no recibido.' });
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'La API key de OpenAI no está configurada.' });
+  }
+
+  try {
+    const transcription = await openai.audio.transcriptions.create({
+      file: { data: req.file.buffer, name: req.file.originalname || 'audio.webm' },
+      model: 'gpt-4o-mini-transcribe',
+      response_format: 'verbose_json',
+      temperature: 0.2
+    });
+
+    const userText = transcription.text || transcription.transcript || '';
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Eres un asistente conversacional en español. Responde de forma breve, amable y clara.'
+        },
+        {
+          role: 'user',
+          content: userText || 'No se detectó audio.'
+        }
+      ],
+      temperature: 0.7
+    });
+
+    const responseText = completion.choices?.[0]?.message?.content?.trim() || '';
+
+    const speechResponse = await openai.audio.speech.create({
+      model: 'gpt-4o-mini-tts',
+      voice: 'alloy',
+      input: responseText || 'Lo siento, no pude entenderte.'
+    });
+
+    const audioBuffer = Buffer.from(await speechResponse.arrayBuffer());
+    const audioBase64 = audioBuffer.toString('base64');
+
+    res.json({
+      transcript: userText,
+      responseText,
+      audioBase64
+    });
+  } catch (error) {
+    console.error('Error en /api/speech', error);
+    res.status(500).json({
+      error: 'Error al comunicarse con OpenAI.',
+      details: error.message
+    });
+  }
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const clientDistPath = path.resolve(__dirname, '../dist');
+
+app.use(express.static(clientDistPath));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(clientDistPath, 'index.html'));
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Servidor escuchando en http://localhost:${PORT}`);
+});

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,148 @@
+.app-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  align-items: center;
+  padding: 2.5rem 1.5rem 3rem;
+  background: radial-gradient(circle at top, #e0f2fe 0%, #f8fafc 55%, #ffffff 100%);
+  color: #0f172a;
+}
+
+.app-header {
+  text-align: center;
+  max-width: 720px;
+  margin-bottom: 2rem;
+}
+
+.app-header h1 {
+  font-size: 2.8rem;
+  margin: 0 0 0.5rem;
+  color: #1d4ed8;
+}
+
+.app-header p {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #334155;
+}
+
+.card {
+  width: min(720px, 100%);
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.record-btn {
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: white;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 25px rgba(59, 130, 246, 0.35);
+}
+
+.record-btn:hover:not(:disabled) {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 16px 30px rgba(59, 130, 246, 0.35);
+}
+
+.record-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.record-btn.recording {
+  background: linear-gradient(135deg, #dc2626, #f97316);
+  box-shadow: 0 10px 25px rgba(220, 38, 38, 0.35);
+}
+
+.status {
+  font-size: 0.95rem;
+  color: #2563eb;
+}
+
+.results {
+  display: grid;
+  gap: 1rem;
+}
+
+.result-block {
+  background: #f8fafc;
+  border-radius: 18px;
+  padding: 1.2rem 1.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.result-block h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #1e293b;
+}
+
+.result-block p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.6;
+}
+
+.error {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.secondary-btn {
+  align-self: center;
+  border: none;
+  background: transparent;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.secondary-btn:hover:not(:disabled) {
+  background-color: rgba(37, 99, 235, 0.1);
+  color: #1e3a8a;
+}
+
+.player {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.app-footer {
+  margin-top: auto;
+  font-size: 0.85rem;
+  color: #64748b;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .app-header h1 {
+    font-size: 2.1rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,171 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import './App.css';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+
+function App() {
+  const mediaRecorderRef = useRef(null);
+  const chunksRef = useRef([]);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const [aiResponse, setAiResponse] = useState('');
+  const [audioSrc, setAudioSrc] = useState('');
+  const [error, setError] = useState('');
+
+  const supportsRecording = useMemo(
+    () => typeof window !== 'undefined' && navigator.mediaDevices?.getUserMedia,
+    []
+  );
+
+  const resetConversation = () => {
+    setTranscript('');
+    setAiResponse('');
+    setAudioSrc('');
+    setError('');
+  };
+
+  const stopRecording = useCallback(() => {
+    mediaRecorderRef.current?.stop();
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    setError('');
+    resetConversation();
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = mediaRecorder;
+      chunksRef.current = [];
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstop = async () => {
+        const audioBlob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        chunksRef.current = [];
+
+        try {
+          setIsProcessing(true);
+          const formData = new FormData();
+          formData.append('audio', audioBlob, 'grabacion.webm');
+
+          const response = await fetch(`${API_BASE_URL}/api/speech`, {
+            method: 'POST',
+            body: formData
+          });
+
+          if (!response.ok) {
+            throw new Error('No se pudo procesar el audio. Intenta nuevamente.');
+          }
+
+          const data = await response.json();
+          setTranscript(data.transcript || '');
+          setAiResponse(data.responseText || '');
+
+          if (data.audioBase64) {
+            const src = `data:audio/wav;base64,${data.audioBase64}`;
+            setAudioSrc(src);
+            const audio = new Audio(src);
+            await audio.play();
+          }
+        } catch (err) {
+          console.error(err);
+          setError(err.message || 'Ocurrió un error inesperado.');
+        } finally {
+          setIsProcessing(false);
+        }
+      };
+
+      mediaRecorder.start();
+      setIsRecording(true);
+    } catch (err) {
+      console.error(err);
+      setError('No se pudo acceder al micrófono. Verifica los permisos del navegador.');
+    }
+  }, []);
+
+  const handleToggleRecording = async () => {
+    if (isRecording) {
+      stopRecording();
+      setIsRecording(false);
+    } else {
+      await startRecording();
+    }
+  };
+
+  return (
+    <div className="app-container">
+      <header className="app-header">
+        <h1>Speach IA</h1>
+        <p>
+          Haz una pregunta hablando con tu micrófono. El asistente de OpenAI
+          responderá con voz.
+        </p>
+      </header>
+
+      <main className="card">
+        <section className="controls">
+          {!supportsRecording && (
+            <p className="error">Tu navegador no soporta captura de audio.</p>
+          )}
+
+          <button
+            className={`record-btn ${isRecording ? 'recording' : ''}`}
+            type="button"
+            onClick={handleToggleRecording}
+            disabled={!supportsRecording || isProcessing}
+          >
+            {isRecording ? 'Detener grabación' : 'Comenzar a hablar'}
+          </button>
+
+          {isProcessing && <p className="status">Procesando tu audio…</p>}
+        </section>
+
+        <section className="results">
+          {transcript && (
+            <div className="result-block">
+              <h2>Lo que dijiste</h2>
+              <p>{transcript}</p>
+            </div>
+          )}
+
+          {aiResponse && (
+            <div className="result-block">
+              <h2>Respuesta del asistente</h2>
+              <p>{aiResponse}</p>
+              {audioSrc && (
+                <audio controls src={audioSrc} className="player" />
+              )}
+            </div>
+          )}
+
+          {error && <p className="error">{error}</p>}
+        </section>
+
+        {(transcript || aiResponse || error) && (
+          <button
+            type="button"
+            className="secondary-btn"
+            onClick={resetConversation}
+            disabled={isProcessing}
+          >
+            Limpiar
+          </button>
+        )}
+      </main>
+
+      <footer className="app-footer">
+        <p>
+          Necesitas configurar la variable <code>OPENAI_API_KEY</code> en el
+          servidor para habilitar la conversación.
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,22 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true
+      }
+    }
+  },
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input: path.resolve(__dirname, 'index.html')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React frontend that graba audio, lo envía a la API y reproduce la respuesta generada
- crear un backend Express que transcribe con OpenAI, genera respuesta y convierte texto a voz
- documentar instalación, variables de entorno y scripts de ejecución

## Testing
- npm install *(fails: registry returned 403)*
- npm run dev *(fails: npm-run-all no está instalado por el fallo anterior)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a25751688332bea4523ae686b945